### PR TITLE
Fix Bug: the correct order of nodes when repeating

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,23 +38,22 @@ function paramsList(params) {
 }
 
 function processRules(rule, params) {
-  rule.nodes.forEach(node => {
+  params.values[0].forEach((_, i) => {
+    let vals = {};
 
-    params.values[0].forEach((_, i) => {
+    params.names.forEach((name, j) => {
+      vals[name] = params.values[j][i];
+    });
+
+    if (params.indexName) vals[params.indexName] = i;
+
+    rule.nodes.forEach(node => {
       const clone = node.clone();
       const proxy = postcss.rule({ nodes: [clone] });
-      let vals = {};
-
-      params.names.forEach((name, j) => {
-        vals[name] = params.values[j][i];
-      });
-
-      if (params.indexName) vals[params.indexName] = i;
 
       vars({ only: vals })(proxy);
       rule.parent.insertBefore(rule, clone);
     });
-
   });
 }
 

--- a/test/cases/nested-iteration.expected.css
+++ b/test/cases/nested-iteration.expected.css
@@ -9,9 +9,6 @@
 .a {
     hello: a
 }
-.b {
-    hello: b
-}
 .a-x {
     color: purple;
     blah: u;
@@ -21,6 +18,9 @@
     color: purple;
     blah: u;
     blah: v
+}
+.b {
+    hello: b
 }
 .b-x {
     color: purple;


### PR DESCRIPTION
The problem is in the order of nodes when repeating,
problem:
repeat a node for all values first, then repeat the second node with all values also ...

my fix:
repeat the nodes with the first value, then the nodes with the second value ...