### PR TITLE
Update postcss to 6.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,10 @@ function processRules(rule, params) {
     rule.nodes.forEach(node => {
       const clone = node.clone();
       const proxy = postcss.rule({ nodes: [clone] });
+      clone.raws = {};  // Cleans raws object
+      if (clone.nodes) {
+        clone.nodes.forEach(n => n.raws = {});
+      }
 
       vars({ only: vals })(proxy);
       rule.parent.insertBefore(rule, clone);
@@ -88,7 +92,7 @@ function processLoop(css, opts) {
   }
 
   if (rulesExists(css)) processLoop(css, opts);
-};
+}
 
 export default postcss.plugin('postcss-each', (opts) => {
   opts = opts || {};

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "url": "https://github.com/outpunk/postcss-each.git"
   },
   "dependencies": {
-    "postcss": "^5.0.21",
-    "postcss-simple-vars": "^2.0.0"
+    "postcss": "^6.0.1",
+    "postcss-simple-vars": "^4.0.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
> Also Node#clone now returns the exact copy of a node. In 6.0 it no longer cleans raws.

The above change breaks this plugin tests. This patch includes an ugly hack for fixing spacing issue.

Please review this before merging into master.
